### PR TITLE
fix(logging): disable debug vim.print commands

### DIFF
--- a/lua/cmp_go_pkgs/source.lua
+++ b/lua/cmp_go_pkgs/source.lua
@@ -21,12 +21,14 @@ local init_items = function(a)
 		arguments = arguments,
 	}, function(arg1, arg2, _)
 		if arg2 == nil and arg1 ~= nil then
-			vim.print("LSP error", arg1)
+			-- Debug log
+			-- vim.print("LSP error", arg1)
 			return
 		end
 
 		if arg1 == nil and arg2 == nil then
-			vim.print("both arg1 and arg2 are nil")
+			-- Debug log
+			-- vim.print("both arg1 and arg2 are nil")
 			return
 		end
 
@@ -70,7 +72,8 @@ end
 source.complete = function(self, _, callback)
 	local ok = self._check_if_inside_imports()
 	if ok == false then
-		vim.print("not inside imports")
+		-- Debug log
+		-- vim.print("not inside imports")
 		callback()
 		return
 	end


### PR DESCRIPTION
While using this plugin, i've noticed that it sometimes prints some debug stuff into vim messages. I think it should only happen when developing, so i commented them out.